### PR TITLE
Added server/services/API.lua on server_script in fxmanifest.lua

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,6 +20,7 @@ client_scripts {
 server_scripts {
     '@oxmysql/lib/MySQL.lua', -- oxmysql dependency
     'server/server.lua',
+    'server/services/API.lua',
     'server/txAdminhandlers.lua',
     'server/dbUpdater.lua'
 }


### PR DESCRIPTION
When using bcc-userlog from bcc-nazar the error:
SCRIPT ERROR: @bcc-nazar/server/main.lua:6: No such export getUserLogAPI in resource bcc-userlog
was on the server also if ensure bcc-userlog was loaded before bcc-nazar

When added the line on fxmanifest.lua the issue disappeared
